### PR TITLE
Relax the dependency of icub-main on Exact version of libicub-main

### DIFF
--- a/.ci_support/migrations/libyarp3101.yaml
+++ b/.ci_support/migrations/libyarp3101.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for libyarp 3.10.1
-  kind: version
-  migration_number: 1
-libyarp:
-- 3.10.1
-migrator_ts: 1732751985.5370722

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: fa06bda5fd2fa9a307e0feb05fb11be216ab1b0f99078cb4222fb70b5a326a76
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libicub-main
@@ -99,7 +99,7 @@ outputs:
         - {{ pin_subpackage("libicub-main", max_pin='x.x.x') }}
     requirements:
       run:
-        - {{ pin_subpackage("libicub-main", exact=True) }}
+        - {{ pin_subpackage("libicub-main", max_pin='x.x.x') }}
         - {{ pin_subpackage("icub-main-python", max_pin='x.x.x') }}
     test:
       commands:


### PR DESCRIPTION
We saw errors like:
~~~
-   - package icub-main-2.7.1-h1841e4b_0 requires libicub-main 2.7.1 h7997109_0, but none of the providers can be installed
~~~

for example in https://github.com/robotology/robotology-superbuild/issues/1761, I think there is no strict reason why the `icub-main` needs to depend on the exact build of `libicub-main`, a dependency on exactly the same version (as done with Python bindings package) is probably enough.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
